### PR TITLE
Adds simple unbind API

### DIFF
--- a/Sources/MFBBinding.h
+++ b/Sources/MFBBinding.h
@@ -36,7 +36,7 @@ extern NSString *const MFBValueTransformerNameBindingOption;
      withKeyPath:(NSString *)keyPath
          options:(NSDictionary<NSString *, id> *)options;
 
-- (void)mfb_unbindAll:(NSString *)binding;
+- (void)mfb_unbind:(NSString *)binding;
 
 /**
  @param keyPath The key-path, relative to the receiver, for which to return the list of corresponding bindings.

--- a/Sources/MFBBinding.h
+++ b/Sources/MFBBinding.h
@@ -36,6 +36,8 @@ extern NSString *const MFBValueTransformerNameBindingOption;
      withKeyPath:(NSString *)keyPath
          options:(NSDictionary<NSString *, id> *)options;
 
+- (void)mfb_unbindAll:(NSString *)binding;
+
 /**
  @param keyPath The key-path, relative to the receiver, for which to return the list of corresponding bindings.
  

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -565,7 +565,7 @@ NSString *const MFBValueTransformerNameBindingOption = @"MFBValueTransformerName
 {
     NSCParameterAssert(binding != nil);
 
-    __auto_type bindings = [self mfb_bindingsForKeyPath:binding];
+    __auto_type bindings = [self mfb_setterBindingsForKeyPath:binding];
 
     [bindings makeObjectsPerformSelector:@selector(unbind)];
 }

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -419,6 +419,11 @@ NSString *const MFBValueTransformerNameBindingOption = @"MFBValueTransformerName
     [bindingController bind];
 }
 
+- (void)mfb_unbindAll:(NSString *)binding
+{
+
+}
+
 - (NSArray<MFBBinding *> *)mfb_bindingsForKeyPath:(NSString *)keyPath
 {
     return [MFBBindingInfo bindingsForObject:self keyPath:keyPath];

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -421,7 +421,11 @@ NSString *const MFBValueTransformerNameBindingOption = @"MFBValueTransformerName
 
 - (void)mfb_unbindAll:(NSString *)binding
 {
+    NSCParameterAssert(binding != nil);
 
+    __auto_type bindings = [self mfb_bindingsForKeyPath:binding];
+
+    [bindings makeObjectsPerformSelector:@selector(unbind)];
 }
 
 - (NSArray<MFBBinding *> *)mfb_bindingsForKeyPath:(NSString *)keyPath

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -82,7 +82,7 @@
     NSCParameterAssert(block != nil);
 
     [_store enumerateKeysAndObjectsUsingBlock:^(NSString *_, NSMutableArray<MFBBinding *> *list, BOOL *__) {
-        for (MFBBinding *binding in list) {
+        for (MFBBinding *binding in [list copy]) {
             block(binding);
         }
     }];

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -14,6 +14,82 @@
 - (void)unbind;
 @end
 
+@interface MFBBindingStore : NSObject
+
+- (void)addBinding:(MFBBinding *)binding forKeyPath:(NSString *)keyPath;
+- (void)removeBinding:(MFBBinding *)binding forKeyPath:(NSString *)keyPath;
+- (NSArray<MFBBinding *> *)bindingsForKeyPath:(NSString *)keyPath;
+
+- (void)enumerateBindingsUsingBlock:(void (^)(MFBBinding *binding))block;
+
+@end
+
+@implementation MFBBindingStore {
+    NSMutableDictionary<NSString *, NSMutableArray<MFBBinding *> *> *_store;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self) {
+        _store = [NSMutableDictionary dictionary];
+    }
+
+    return self;
+}
+
+- (void)addBinding:(MFBBinding *)binding forKeyPath:(NSString *)keyPath
+{
+    NSCParameterAssert(binding != nil);
+    NSCParameterAssert(keyPath != nil);
+
+    __auto_type list = _store[keyPath];
+
+    if (!list) {
+        list = [NSMutableArray arrayWithObject:binding];
+        _store[keyPath] = list;
+    } else {
+        [list addObject:binding];
+    }
+}
+
+- (void)removeBinding:(MFBBinding *)binding forKeyPath:(NSString *)keyPath
+{
+    NSCParameterAssert(binding != nil);
+    NSCParameterAssert(keyPath != nil);
+
+    __auto_type list = _store[keyPath];
+
+    [list removeObject:binding];
+}
+
+- (NSArray<MFBBinding *> *)bindingsForKeyPath:(NSString *)keyPath
+{
+    NSCParameterAssert(keyPath != nil);
+
+    __auto_type list = _store[keyPath];
+
+    if (list.count == 0) {
+        return @[];
+    }
+
+    return [list copy];
+}
+
+- (void)enumerateBindingsUsingBlock:(void (^)(MFBBinding *))block
+{
+    NSCParameterAssert(block != nil);
+
+    [_store enumerateKeysAndObjectsUsingBlock:^(NSString *_, NSMutableArray<MFBBinding *> *list, BOOL *__) {
+        for (MFBBinding *binding in list) {
+            block(binding);
+        }
+    }];
+}
+
+@end
+
 @interface MFBBindingInfo : NSObject
 + (void)registerBinding:(MFBBinding *)binding forObject:(id)obj;
 + (void)unregisterBinding:(MFBBinding *)binding forObject:(id)obj;
@@ -23,7 +99,8 @@
 @implementation MFBBindingInfo {
     __weak id _object;
 
-    NSMutableArray *_bindings;
+    MFBBindingStore *_setterBindings;
+    MFBBindingStore *_getterBindings;
 }
 
 static const void *BindingAssociationKey = &BindingAssociationKey;
@@ -120,50 +197,91 @@ static void TweakDeallocForUnbindingIfNeeded(id obj)
         TweakDeallocForUnbindingIfNeeded(object);
 
         _object = object;
-        _bindings = [NSMutableArray new];
+        _setterBindings = [MFBBindingStore new];
+        _getterBindings = [MFBBindingStore new];
     }
     return self;
 }
 
 - (void)_registerBinding:(MFBBinding *)binding
 {
-    [_bindings addObject:binding];
+    if (binding.secondObject == _object) {
+        [_setterBindings addBinding:binding forKeyPath:binding.secondKeyPath];
+    } else if (binding.firstObject == _object) {
+        [_setterBindings addBinding:binding forKeyPath:binding.firstKeyPath];
+    }
+
+    if (binding.firstObject == _object) {
+        [_getterBindings addBinding:binding forKeyPath:binding.firstKeyPath];
+    } else if (binding.secondObject == _object) {
+        [_getterBindings addBinding:binding forKeyPath:binding.secondKeyPath];
+    }
 }
 
 - (void)_unregisterBinding:(MFBBinding *)binding
 {
-    [_bindings removeObject:binding];
+    if (binding.secondObject == _object) {
+        [_setterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
+    } else if (binding.firstObject == _object) {
+        [_setterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
+    }
+
+    if (binding.firstObject == _object) {
+        [_getterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
+    } else if (binding.secondObject == _object) {
+        [_getterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
+    }
 }
 
 - (NSArray<MFBBinding *> *)_bindingsForKeyPath:(NSString *)keyPath
 {
-    return [_bindings filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(MFBBinding *binding, NSDictionary<NSString *,id> *_) {
-        return (binding.firstObject == _object && [binding.firstKeyPath isEqualToString:keyPath])
-        || (binding.secondObject == _object && [binding.secondKeyPath isEqualToString:keyPath]);
-    }]];
+    __auto_type setterBindings = [self _setterBindingsForKeyPath:keyPath];
+    __auto_type getterBindings = [self _getterBindingsForKeyPath:keyPath];
+
+    __auto_type uniqueBindings = [NSMutableSet<MFBBinding *> setWithArray:setterBindings];
+    [uniqueBindings addObjectsFromArray:getterBindings];
+
+    return uniqueBindings.allObjects;
 }
 
 - (NSArray<MFBBinding *> *)_getterBindingsForKeyPath:(NSString *)keyPath
 {
-    return [_bindings filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(MFBBinding *binding, NSDictionary<NSString *,id> *_) {
-        return (binding.firstObject == _object && [binding.firstKeyPath isEqualToString:keyPath])
-        || (binding.twoWay && binding.secondObject == _object && [binding.secondKeyPath isEqualToString:keyPath]);
-    }]];
+    __auto_type list = [_getterBindings bindingsForKeyPath:keyPath];
+
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(MFBBinding *evaluatedObject, NSDictionary<NSString *,id> *_) {
+        if (evaluatedObject.secondObject == _object) {
+            return evaluatedObject.twoWay;
+        }
+
+        return YES;
+    }];
+
+    return [list filteredArrayUsingPredicate:predicate];
 }
 
 - (NSArray<MFBBinding *> *)_setterBindingsForKeyPath:(NSString *)keyPath
 {
-    return [_bindings filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(MFBBinding *binding, NSDictionary<NSString *,id> *_) {
-        return (binding.twoWay && binding.firstObject == _object && [binding.firstKeyPath isEqualToString:keyPath])
-        || (binding.secondObject == _object && [binding.secondKeyPath isEqualToString:keyPath]);
-    }]];
+    __auto_type list = [_setterBindings bindingsForKeyPath:keyPath];
+
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(MFBBinding *evaluatedObject, NSDictionary<NSString *,id> *_) {
+        if (evaluatedObject.firstObject == _object) {
+            return evaluatedObject.twoWay;
+        }
+
+        return YES;
+    }];
+
+    return [list filteredArrayUsingPredicate:predicate];
 }
 
 - (void)_unbindAll
 {
-    for (MFBBinding *binding in _bindings.copy) {
+    __auto_type iteration = ^(MFBBinding *binding) {
         [binding unbind];
-    }
+    };
+
+    [_getterBindings enumerateBindingsUsingBlock:iteration];
+    [_setterBindings enumerateBindingsUsingBlock:iteration];
 }
 
 @end
@@ -196,7 +314,16 @@ static void *SecondToFirstKey = &SecondToFirstKey;
 
     _firstObject = firstObject;
 
-    [MFBBindingInfo registerBinding:self forObject:_firstObject];
+    [self registerIfValid];
+}
+
+- (void)setFirstKeyPath:(NSString *)firstKeyPath
+{
+    NSCParameterAssert(firstKeyPath != nil);
+
+    _firstKeyPath = [firstKeyPath copy];
+
+    [self registerIfValid];
 }
 
 - (void)setSecondObject:(id)secondObject
@@ -209,7 +336,16 @@ static void *SecondToFirstKey = &SecondToFirstKey;
 
     _secondObject = secondObject;
 
-    [MFBBindingInfo registerBinding:self forObject:_secondObject];
+    [self registerIfValid];
+}
+
+- (void)setSecondKeyPath:(NSString *)secondKeyPath
+{
+    NSCParameterAssert(secondKeyPath != nil);
+
+    _secondKeyPath = [secondKeyPath copy];
+
+    [self registerIfValid];
 }
 
 - (NSValueTransformer *)valueTransformer
@@ -227,6 +363,16 @@ static void *SecondToFirstKey = &SecondToFirstKey;
 
 
 #pragma mark - Private Methods
+
+- (void)registerIfValid
+{
+    if (!_firstObject || !_firstKeyPath || !_secondObject || !_secondKeyPath) {
+        return;
+    }
+
+    [MFBBindingInfo registerBinding:self forObject:_firstObject];
+    [MFBBindingInfo registerBinding:self forObject:_secondObject];
+}
 
 - (void)bind
 {
@@ -280,6 +426,8 @@ static void *SecondToFirstKey = &SecondToFirstKey;
     if (!_flags.binded) {
         return;
     }
+
+    _flags.binded = NO;
 
     [_firstObject removeObserver:self forKeyPath:_firstKeyPath context:FirstToSecondKey];
 

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -561,7 +561,7 @@ NSString *const MFBValueTransformerNameBindingOption = @"MFBValueTransformerName
     [bindingController bind];
 }
 
-- (void)mfb_unbindAll:(NSString *)binding
+- (void)mfb_unbind:(NSString *)binding
 {
     NSCParameterAssert(binding != nil);
 

--- a/Sources/MFBBinding.m
+++ b/Sources/MFBBinding.m
@@ -220,17 +220,11 @@ static void TweakDeallocForUnbindingIfNeeded(id obj)
 
 - (void)_unregisterBinding:(MFBBinding *)binding
 {
-    if (binding.secondObject == _object) {
-        [_setterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
-    } else if (binding.firstObject == _object) {
-        [_setterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
-    }
+    [_setterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
+    [_setterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
 
-    if (binding.firstObject == _object) {
-        [_getterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
-    } else if (binding.secondObject == _object) {
-        [_getterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
-    }
+    [_getterBindings removeBinding:binding forKeyPath:binding.firstKeyPath];
+    [_getterBindings removeBinding:binding forKeyPath:binding.secondKeyPath];
 }
 
 - (NSArray<MFBBinding *> *)_bindingsForKeyPath:(NSString *)keyPath

--- a/Tests/MFBBindingTests.m
+++ b/Tests/MFBBindingTests.m
@@ -1408,7 +1408,7 @@
     XCTAssertEqualObjects(_objectA.replacedIndexes, indexes);
 }
 
-- (void)test_unbindAll_RemovesMatchingBinding
+- (void)test_unbindAll_RemovesMatchingBindings
 {
     __auto_type object1 = [MFBBindingTestObjectA new];
     __auto_type object2 = [MFBBindingTestObjectB new];
@@ -1424,10 +1424,16 @@
           withKeyPath:NSStringFromSelector(@selector(propertyA))
               options:nil];
 
+    [object3 mfb_bind:NSStringFromSelector(@selector(arrayA))
+             toObject:object2
+          withKeyPath:NSStringFromSelector(@selector(propertyB))
+              options:nil];
+
     [object2 mfb_unbindAll:NSStringFromSelector(@selector(propertyB))];
 
     XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 0);
     XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayB))].count, 1);
+    XCTAssertEqual([object3 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayA))].count, 0);
 }
 
 @end

--- a/Tests/MFBBindingTests.m
+++ b/Tests/MFBBindingTests.m
@@ -1408,4 +1408,26 @@
     XCTAssertEqualObjects(_objectA.replacedIndexes, indexes);
 }
 
+- (void)test_unbindAll_RemovesMatchingBinding
+{
+    __auto_type object1 = [MFBBindingTestObjectA new];
+    __auto_type object2 = [MFBBindingTestObjectB new];
+    __auto_type object3 = [MFBBindingTestObjectA new];
+
+    [object2 mfb_bind:NSStringFromSelector(@selector(propertyB))
+             toObject:object1
+          withKeyPath:NSStringFromSelector(@selector(propertyA))
+              options:nil];
+
+    [object2 mfb_bind:NSStringFromSelector(@selector(arrayB))
+             toObject:object3
+          withKeyPath:NSStringFromSelector(@selector(propertyA))
+              options:nil];
+
+    [object2 mfb_unbindAll:NSStringFromSelector(@selector(propertyB))];
+
+    XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 0);
+    XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayB))].count, 1);
+}
+
 @end

--- a/Tests/MFBBindingTests.m
+++ b/Tests/MFBBindingTests.m
@@ -1408,7 +1408,7 @@
     XCTAssertEqualObjects(_objectA.replacedIndexes, indexes);
 }
 
-- (void)test_unbind_RemovesMatchingBindings
+- (void)test_unbind_RemovesMatchingSetterBindings
 {
     __auto_type object1 = [MFBBindingTestObjectA new];
     __auto_type object2 = [MFBBindingTestObjectB new];
@@ -1431,9 +1431,10 @@
 
     [object2 mfb_unbind:NSStringFromSelector(@selector(propertyB))];
 
-    XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 0);
-    XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayB))].count, 1);
-    XCTAssertEqual([object3 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayA))].count, 0);
+    XCTAssertEqual([object2 mfb_setterBindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 0);
+    XCTAssertEqual([object2 mfb_setterBindingsForKeyPath:NSStringFromSelector(@selector(arrayB))].count, 1);
+    XCTAssertEqual([object2 mfb_getterBindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 1);
+    XCTAssertEqual([object3 mfb_setterBindingsForKeyPath:NSStringFromSelector(@selector(arrayA))].count, 1);
 }
 
 /*

--- a/Tests/MFBBindingTests.m
+++ b/Tests/MFBBindingTests.m
@@ -1460,8 +1460,8 @@
              toObject:objectA
           withKeyPath:NSStringFromSelector(@selector(propertyA))
               options:@{
-                        MFBRetainObserverBindingOption : @YES,
-                        }];
+                  MFBRetainObserverBindingOption : @YES,
+              }];
 
     objectC = nil;
     objectB = nil;

--- a/Tests/MFBBindingTests.m
+++ b/Tests/MFBBindingTests.m
@@ -1408,7 +1408,7 @@
     XCTAssertEqualObjects(_objectA.replacedIndexes, indexes);
 }
 
-- (void)test_unbindAll_RemovesMatchingBindings
+- (void)test_unbind_RemovesMatchingBindings
 {
     __auto_type object1 = [MFBBindingTestObjectA new];
     __auto_type object2 = [MFBBindingTestObjectB new];
@@ -1429,7 +1429,7 @@
           withKeyPath:NSStringFromSelector(@selector(propertyB))
               options:nil];
 
-    [object2 mfb_unbindAll:NSStringFromSelector(@selector(propertyB))];
+    [object2 mfb_unbind:NSStringFromSelector(@selector(propertyB))];
 
     XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(propertyB))].count, 0);
     XCTAssertEqual([object2 mfb_bindingsForKeyPath:NSStringFromSelector(@selector(arrayB))].count, 1);


### PR DESCRIPTION
It's a prerequisite for table/collection view support.

Unbinding method relies on a binding storage. Since the binding storage is not optimized to be used for "real" code and considered "asserts and tests only", it has to be optimized a bit.